### PR TITLE
Fix MakeOldAreaInfo so retail C2 _RES.TXT files work again

### DIFF
--- a/Menu2/Resources.cpp
+++ b/Menu2/Resources.cpp
@@ -82,7 +82,6 @@ AreaInfo MakeOldAreaInfo(int index, int price)
 			std::getline(f, line);
 			a.m_Description.push_back(line);
 		}
-		f.close();
 	}
 	else
 	{


### PR DESCRIPTION
This function uses `f.is_open()` at the end to check if it was able to read the area description, although it just closed the file directly after successfully reading the file.

Just removing the "early" close fixes the error, and makes the menu work again with retail C2 _RES.TXT files.